### PR TITLE
Fix a typo in a champion name

### DIFF
--- a/stage-0-proposals.md
+++ b/stage-0-proposals.md
@@ -19,7 +19,7 @@ Stage 0 proposals have been presented to the committee and not rejected definiti
 |   | [Function Expression Decorators](https://goo.gl/8MmCMG)                                                                                  | Igor Minar                      | 0     |
 | 🚀 | [Zones](https://github.com/domenic/zones) ([spec](https://domenic.github.io/zones/))                                                     | Domenic Denicola & Miško Hevery | 0     |
 |   | [Updates to Tail Calls to include an explicit syntactic opt-in](https://github.com/tc39/proposal-ptc-syntax)                             | Brian Terlson & Eric Faust      | 0     |
-| 🚀 | [Object enumerables](https://github.com/leobalter/object-enumerables)                                                                    | Leo Balter & Jonn-David Dalton  | 0     |
+| 🚀 | [Object enumerables](https://github.com/leobalter/object-enumerables)                                                                    | Leo Balter & John-David Dalton  | 0     |
 
 🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.
 


### PR DESCRIPTION
From Jonn-David -> John-David.

LGTY @jdalton? 😃 