### PR TITLE
[finished] add expected publication year

### DIFF
--- a/finished-proposals.md
+++ b/finished-proposals.md
@@ -2,12 +2,12 @@
 
 Finished proposals are proposals that have reached stage 4, and are included in the [latest draft](https://tc39.github.io/ecma262/) of the specification.
 
-| Proposal                                                                               | Champion(s)                    | TC39 meeting notes |
-|----------------------------------------------------------------------------------------|--------------------------------|--------------------|
-| [Array.prototype.includes](https://github.com/tc39/Array.prototype.includes/)          | Domenic Denicola, Rick Waldron | [November 2015](https://github.com/rwaldron/tc39-notes/blob/924122cdc03e9ee2afbe8014193f845bddc6da2d/es7/2015-11/nov-17.md#arrayprototypeincludes)
-| [Exponentiation Operator](https://github.com/rwaldron/exponentiation-operator)         | Rick Waldron                   | [January 2016](https://github.com/rwaldron/tc39-notes/blob/924122cdc03e9ee2afbe8014193f845bddc6da2d/es7/2016-01/2016-01-28.md#5xviii-exponentiation-operator-rw)
-| [Object.values/Object.entries](https://github.com/tc39/proposal-object-values-entries) | Jordan Harband                 | [March 2016](https://github.com/rwaldron/tc39-notes/blob/80d8837eefdb74ec5532c0fd034c51c83e4b8882/es7/2016-03/march-29.md#objectvalues--objectentries)
-| [String padding](https://github.com/tc39/proposal-string-pad-start-end)                                   | Jordan Harband & Rick Waldron      | May 2016
-| [Object.getOwnPropertyDescriptors](https://github.com/ljharb/proposal-object-getownpropertydescriptors)   | Jordan Harband & Andrea Giammarchi | May 2016
+| Proposal                                                                               | Champion(s)                    | TC39 meeting notes | Expected Publication Year |
+|----------------------------------------------------------------------------------------|--------------------------------|--------------------|---------------------------|
+| [Array.prototype.includes](https://github.com/tc39/Array.prototype.includes/)          | Domenic Denicola, Rick Waldron | [November 2015](https://github.com/rwaldron/tc39-notes/blob/924122cdc03e9ee2afbe8014193f845bddc6da2d/es7/2015-11/nov-17.md#arrayprototypeincludes) | 2016
+| [Exponentiation Operator](https://github.com/rwaldron/exponentiation-operator)         | Rick Waldron                   | [January 2016](https://github.com/rwaldron/tc39-notes/blob/924122cdc03e9ee2afbe8014193f845bddc6da2d/es7/2016-01/2016-01-28.md#5xviii-exponentiation-operator-rw) | 2016
+| [Object.values/Object.entries](https://github.com/tc39/proposal-object-values-entries) | Jordan Harband                 | [March 2016](https://github.com/rwaldron/tc39-notes/blob/80d8837eefdb74ec5532c0fd034c51c83e4b8882/es7/2016-03/march-29.md#objectvalues--objectentries) | 2017
+| [String padding](https://github.com/tc39/proposal-string-pad-start-end)                                   | Jordan Harband & Rick Waldron      | May 2016 | 2017
+| [Object.getOwnPropertyDescriptors](https://github.com/ljharb/proposal-object-getownpropertydescriptors)   | Jordan Harband & Andrea Giammarchi | May 2016 | 2017
 
 See also the [stage 0 proposals](stage-0-proposals.md), [active proposals](README.md), and [inactive proposals](inactive-proposals.md) documents.


### PR DESCRIPTION
Although basically "anything by the end of January in year YYYY will make it into YYYY", it's clearer and more explicit to document the expected year inline.