### PR TITLE
Add nested `import` proposal to the stage-0 list

### DIFF
--- a/stage-0-proposals.md
+++ b/stage-0-proposals.md
@@ -21,6 +21,7 @@ Stage 0 proposals have been presented to the committee and not rejected definiti
 |   | [Updates to Tail Calls to include an explicit syntactic opt-in](https://github.com/tc39/proposal-ptc-syntax)                             | Brian Terlson & Eric Faust      | 0     |
 | 🚀 | [Object enumerables](https://github.com/leobalter/object-enumerables)                                                                    | Leo Balter & John-David Dalton  | 0     |
 | 🚀 | [Unicode property escapes `\p{…}` and `\P{…}` in regular expressions](https://github.com/mathiasbynens/es-regexp-unicode-property-escapes) | Mathias Bynens, Daniel Ehrenberg, Brian Terlson   | 0     |
+| 🚀? | [Nested `import` declarations](https://github.com/tc39/ecma262/pull/646) | Ben Newman, Meteor Development Group | 0 |
 
 🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.
 


### PR DESCRIPTION
I believe this proposal meets most of the requirements to advance to stage 1, but I realize I did not meet the deadline of posting it seven days before the meeting, hence the ":rocket:?".