### PR TITLE
Withdraw ArrayBuffer.transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Proposals follow [this process document](https://tc39.github.io/process-document
 |   | [Promise.prototype.finally](https://github.com/tc39/proposal-promise-finally)                             | Jordan Harband                     | 2 |
 |   | [Class and Property Decorators](http://tc39.github.io/proposal-decorators/)                               | Yehuda Katz and Brian Terlson    | 2 |
 |   | [Date.parse fallback semantics](https://github.com/mrrrgn/proposal-date-time-string-format)               | Morgan Phillips                    | 1 |
-|   | [ArrayBuffer.transfer](https://gist.github.com/lukewagner/2735af7eea411e18cf20)                           | Luke Wagneer & Allen Wirfs-Brock   | 1 |
 | 🚀 | [`export * as ns from "mod";` statements](https://github.com/leebyron/ecmascript-export-ns-from)          | Lee Byron                          | 1 |
 | 🚀 | [`export v from "mod";` statements](https://github.com/leebyron/ecmascript-export-default-from)           | Lee Byron                          | 1 |
 |   | [Observable](https://github.com/zenparsing/es-observable)                                                 | Kevin Smith & Jafar Husain         | 1 |

--- a/inactive-proposals.md
+++ b/inactive-proposals.md
@@ -9,6 +9,8 @@ Inactive proposals are proposals that at one point were presented to the committ
 | [Error.isError](https://github.com/ljharb/proposal-is-error) | Jordan Harband | Withdrawn: in favor of a future proposal to standardize Error stack traces |
 | [Set/Map.prototype.toJSON](https://github.com/DavidBruant/Map-Set.prototype.toJSON) | David Bruant and Jordan Harband | Rejected: better solved by a custom replacer function. |
 | [Typed Objects](https://github.com/dslomov/typed-objects-es7) | Dmitry Lomov, Niko Matsakis | [Abandoned](https://github.com/tc39/ecma262/commit/02455e5e2964f62b13818c6fd23289381ecafdf8). |
-| [Object enumerables](https://github.com/leobalter/object-enumerables) | Leo Balter & John-David Dalton | Rejected
+| [Object enumerables](https://github.com/leobalter/object-enumerables) | Leo Balter & John-David Dalton | Rejected |
+| [ArrayBuffer.transfer](https://gist.github.com/lukewagner/2735af7eea411e18cf20) | Luke Wagner & Allen Wirfs-Brock | Withdrawn
+
 
 See also the [stage 0 proposals](stage-0-proposals.md), [active proposals](README.md), and [finished proposals](finished-proposals.md) documents.


### PR DESCRIPTION
Withdraw the ArrayBuffer.transfer proposal, which has been inactive. I believe the only implementation was in SpiderMonkey, which has since then been backed out. May revive in the future with SAB, but there is currently no real interest.