### PR TITLE
Update champions for stage 0 proposals

### DIFF
--- a/stage-0-proposals.md
+++ b/stage-0-proposals.md
@@ -14,7 +14,7 @@ Stage 0 proposals are either
 |   | Annex B - HTML Attribute Event Handlers                                                                                                  | Allen Wirfs-Brock               | 0     |
 |   | [Reflect.isCallable/Reflect.isConstructor](https://github.com/caitp/TC39-Proposals/blob/master/tc39-reflect-isconstructor-iscallable.md) | Caitlin Potter                  | 0     |
 |   | [Additional metaproperties](https://github.com/allenwb/ESideas/blob/master/ES7MetaProps.md)                                              | Allen Wirfs-Brock               | 0     |
-|   | [Function Bind Syntax](https://github.com/zenparsing/es-function-bind)                                                                   | Kevin Smith                     | 0     |
+|   | [Function Bind Syntax](https://github.com/zenparsing/es-function-bind)                                                                   | Brian Terlson & Matthew Podwysocki | 0     |
 |   | [Do Expressions](http://wiki.ecmascript.org/doku.php?id=strawman:do_expressions)                                                         | Andreas Rossberg                | 0     |
 |   | [RegExp](https://github.com/goyakin/es-regexp)                                                                                | Gorkem Yakin, Brian Terlson, & Nozomu Katō | 0     |
 |   | [64-Bit Integer Operations](https://gist.github.com/BrendanEich/4294d5c212a6d2254703)                                                    | Brendan Eich                    | 0     |


### PR DESCRIPTION
Based on https://github.com/tc39/proposal-bind-operator/issues/35#issuecomment-232807558 and the fact Dmitry's left TC39.

One thing I don't sure is if I should move Structured Clone to Inactive Proposals instead (same as for Typed Objects), because there is no any info about new champions for a long time.