### PR TITLE
Add Dynamic Module Reform to Stage 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ Proposals follow [this process document](https://tc39.github.io/process-document
 |   | [RegExp named capture groups](https://github.com/tc39/proposal-regexp-named-groups)                       | Daniel Ehrenberg, Brian Terlson    | 1 |
 |   | [`s` (`dotAll`) flag for regular expressions](https://github.com/mathiasbynens/es-regexp-dotall-flag)     | Mathias Bynens, Brian Terlson      | 1 |
 |   | [`Promise.try`](https://github.com/ljharb/proposal-promise-try)                                           | Jordan Harband                     | 1 |
-|   | [64-Bit Integer Operations](https://gist.github.com/BrendanEich/4294d5c212a6d2254703) [alt link](https://github.com/BrendanEich/ecma262/tree/int64) | Brendan Eich                       | 1 |
-|
+|   | [64-Bit Integer Operations](https://gist.github.com/BrendanEich/4294d5c212a6d2254703) [alt link](https://github.com/BrendanEich/ecma262/tree/int64) | Brendan Eich | 1 |
+|   | [Dynamic Module Reform](https://github.com/caridy/proposal-dynamic-modules)                               | Caridy Patiño                     | 1 |
+
 
 🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.
 


### PR DESCRIPTION
I [notice](https://ecmascript-daily.github.io/ecmascript/2016/12/22/ecmascript-proposals) that [Dynamic Module Reform](https://github.com/caridy/proposal-dynamic-modules "Dynamic Module Reform") is now on Stage 1.
But, this proposal didn't exist on the list and I add it.

- https://github.com/rwaldron/tc39-notes/blob/master/es7/2016-11/nov-30.md#conclusionresolution-2
- https://github.com/JSFoundation/standards/blob/master/reports/TC39/2016-11.md#dynamic-modules-reform
