### PR TITLE
Remove “do-expressions“ from Stage 0 as they're Stage 1 now

### DIFF
--- a/stage-0-proposals.md
+++ b/stage-0-proposals.md
@@ -15,7 +15,6 @@ Stage 0 proposals are either
 |   | [Reflect.isCallable/Reflect.isConstructor](https://github.com/caitp/TC39-Proposals/blob/master/tc39-reflect-isconstructor-iscallable.md) | Caitlin Potter                  | 0     |
 |   | [Additional metaproperties](https://github.com/allenwb/ESideas/blob/master/ES7MetaProps.md)                                              | Allen Wirfs-Brock               | 0     |
 |   | [Function Bind Syntax](https://github.com/zenparsing/es-function-bind)                                                                   | Brian Terlson & Matthew Podwysocki | 0     |
-|   | [Do Expressions](http://wiki.ecmascript.org/doku.php?id=strawman:do_expressions)                                                         | Andreas Rossberg                | 0     |
 |   | [Method Parameter Decorators](https://goo.gl/r1XT9b)                                                                                     | Igor Minar                      | 0     |
 |   | [Function Expression Decorators](https://goo.gl/8MmCMG)                                                                                  | Igor Minar                      | 0     |
 |   | [Zones](https://github.com/domenic/zones) ([spec](https://domenic.github.io/zones/))                                                     | Domenic Denicola & Miško Hevery | 0     |


### PR DESCRIPTION
While I'm not entirely sure the proposals on both lists are the same (because of different links and champion), the one on Stage 1 seems to be a more advanced version of the one in the list for Stage 0.
If this is the case, the proposal should be removed from the list for Stage 0.