### PR TITLE
Update name and link for Null Propagation -> Optional Chaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This list contains only stage 1 proposals and higher that have not yet been with
 |   | [`of` and `from` on collection constructors](https://github.com/leobalter/proposal-setmap-offrom)           | Leo Balter                         | 1 |
 |   | Generator arrow functions (`=>*`)                                                                           | Brendan Eich, Domenic Denicola     | 1 |
 |   | [`Promise.try`](https://github.com/ljharb/proposal-promise-try)                                             | Jordan Harband                     | 1 |
-|   | [Null Propagation](https://docs.google.com/presentation/d/11O_wIBBbZgE1bMVRJI8kGnmC6dWCBOwutbN9SWOK0fU/view) | Gabriel Isenberg                  | 1 |
+|   | [Optional Chaining](https://github.com/tc39/proposal-optional-chaining)                                      | Gabriel Isenberg                  | 1 |
 |   | [`Math.signbit`: IEEE-754 sign bit](http://jfbastien.github.io/papers/Math.signbit.html)                     | JF Bastien                        | 1 |
 |   | [Error stacks](https://github.com/ljharb/proposal-error-stacks)                                              | Jordan Harband                    | 1 |
 |   | [`do` expressions](https://gist.github.com/dherman/1c97dfb25179fa34a41b5fff040f9879)                         | Dave Herman                       | 1 |


### PR DESCRIPTION
Update the name of the proposal from "Null Propagation" to "Optional Chaining". Also, link to the TC39 proposal repo tc39/proposal-optional-chaining instead of the slides for Null Propagation.