### PR TITLE
 separate sections for each stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,59 +11,59 @@
 Proposals follow [this process document](https://tc39.github.io/process-document/).
 This list contains only stage 1 proposals and higher that have not yet been withdrawn/rejected, or become finished.
 
-| 🚀 | Proposal                                                         | Champion                                        | Stage |
-|---|------------------------------------------------------------------|-------------------------------------------------|-------|
-|   | [`Function.prototype.toString` revision][function-to-string]     | Michael Ficarra                                 | 3 |
-|   | [`global`][global]                                               | Jordan Harband                                  | 3 |
-|   | [Rest/Spread Properties][object-rest-spread]                     | Sebastian Markbage                              | 3 |
-|   | [Asynchronous Iteration][async-iteration]                        | Domenic Denicola                                | 3 |
-|   | [`import()`][dynamic-import]                                     | Domenic Denicola                                | 3 |
-|   | [RegExp Lookbehind Assertions][lookbehind]                       | Daniel Ehrenberg                                | 3 |
-|   | [RegExp Unicode Property Escapes][unicode-escapes]               | Brian Terlson, Daniel Ehrenberg, Mathias Bynens | 3 |
-|   | [RegExp named capture groups][named-groups]                      | Daniel Ehrenberg, Brian Terlson                 | 3 |
-|   | [`s` (`dotAll`) flag for regular expressions][dot-all]           | Mathias Bynens, Brian Terlson                   | 3 |
-|   | [Legacy RegExp features in JavaScript][regexp-legacy]            | Mark Miller, Claude Pache                       | 3 |
-|   | [`Promise.prototype.finally`][finally]                           | Jordan Harband                                  | 3 |
-|   | [BigInt][bigint]                                                 | Daniel Ehrenberg                                | 3 |
-|   | [Class Fields][class-fields]                                     | Daniel Ehrenberg, Jeff Morrison                 | 3 |
-|   | [Optional catch binding][optional-catch]                         | Michael Ficarra                                 | 3 |
-|   | [`import.meta`][import-meta]                                     | Domenic Denicola                                | 3 |
-|   | [Private methods and accessors][private-methods]                 | Daniel Ehrenberg, Kevin Gibbons                 | 3 |
-|   | [`function.sent` metaproperty][function-sent]                    | Allen Wirfs-Brock                               | 2 |
-|   | [`String.prototype.{trimStart,trimEnd}`][trims]                  | Sebastian Markbage                              | 2 |
-|   | [Class and Property Decorators][decorators] ([update][unified-class]) | Yehuda Katz and Brian Terlson              | 2 |
-|   | [Numeric separators][numeric_separators]                         | Sam Goto, Rick Waldron                          | 2 |
-|   | [Array.prototype.flat{Map,ten}][flat]                            | Brian Terlson, Michael Ficarra                  | 2 |
-|   | [Throw expressions][throw-expressions]                           | Rob Buckton                                     | 2 |
-|   | [`String#matchAll`][matchall]                                    | Jordan Harband                                  | 2 |
-|   | [`Date.parse` fallback semantics][date-parse]                    | Morgan Phillips                                 | 1 |
-|   | [`export v from "mod";` statements][export-from]                 | Ben Newman and John-David Dalton                | 1 |
-| 🚀 | [Observable][observable]                                         | Jafar Husain and Mark Miller                    | 1 |
-|   | [WeakRefs][weakrefs]                                             | Dean Tribble                                    | 1 |
-|   | [Frozen Realms][frozen-realms]                                   | Mark S. Miller, Chip Morningstar, Caridy Patiño | 1 |
-|   | [`Math` Extensions][more-math]                                   | Rick Waldron                                    | 1 |
-|   | [`of` and `from` on collection constructors][collection-of-from] | Leo Balter                                      | 1 |
-|   | Generator arrow functions (`=>*`)                                | Brendan Eich, Domenic Denicola                  | 1 |
-|   | [`Promise.try`][try]                                             | Jordan Harband                                  | 1 |
-|   | [Optional Chaining][chaining]                                    | Gabriel Isenberg                                | 1 |
-|   | [`Math.signbit`: IEEE-754 sign bit][signbit]                     | JF Bastien                                      | 1 |
-|   | [Error stacks][stacks]                                           | Jordan Harband                                  | 1 |
-|   | [`do` expressions][do]                                           | Dave Herman                                     | 1 |
-|   | [Realms][realms]                                                 | Dave Herman, Mark Miller, Caridy Patiño         | 1 |
-|   | [Temporal][temporal]                                             | Maggie Pint, Brian Terlson                      | 1 |
-|   | [Float16 on TypedArrays, DataView, Math.hfround][float16s]       | Leo Balter                                      | 1 |
-|   | [Atomics.waitNonblocking][nonblocking]                           | Shu-yu Guo, Lars Hansen                         | 1 |
-|   | [`Symbol.prototype.description`][symbol-description]             | Michael Ficarra                                 | 1 |
-|   | change Number.parseInt/parseFloat to not coerce null/undefined/NaN (repo link TBD) | Brendan Eich                  | 1 |
-|   | [Binary AST][binary-ast]                                         | Shu-yu Guo                                      | 1 |
-|   | [Pipeline Operator][pipeline]                                    | Daniel Ehrenberg                                | 1 |
-|   | [Extensible numeric literals][extensible-literals]               | Daniel Ehrenberg                                | 1 |
-|   | [First-Class Protocols][protocols]                               | Michael Ficarra                                 | 1 |
-|   | [JSON superset][json-superset]                                   | Mark Miller, Richard Gibson, Mathias Bynens     | 1 |
-|   | [Nullary coalescing operator][nullary-coalescing]                | Gabriel Isenberg                                | 1 |
-|   | [Partial application][partial-application]                       | Ron Buckton                                     | 1 |
+| :rocket: | Proposal                                                 | Champion                                        | Stage |
+|--|------------------------------------------------------------------|-------------------------------------------------|-------|
+|  | [`Function.prototype.toString` revision][function-to-string]     | Michael Ficarra                                 | 3 |
+|  | [`global`][global]                                               | Jordan Harband                                  | 3 |
+|  | [Rest/Spread Properties][object-rest-spread]                     | Sebastian Markbage                              | 3 |
+|  | [Asynchronous Iteration][async-iteration]                        | Domenic Denicola                                | 3 |
+|  | [`import()`][dynamic-import]                                     | Domenic Denicola                                | 3 |
+|  | [RegExp Lookbehind Assertions][lookbehind]                       | Daniel Ehrenberg                                | 3 |
+|  | [RegExp Unicode Property Escapes][unicode-escapes]               | Brian Terlson, Daniel Ehrenberg, Mathias Bynens | 3 |
+|  | [RegExp named capture groups][named-groups]                      | Daniel Ehrenberg, Brian Terlson                 | 3 |
+|  | [`s` (`dotAll`) flag for regular expressions][dot-all]           | Mathias Bynens, Brian Terlson                   | 3 |
+|  | [Legacy RegExp features in JavaScript][regexp-legacy]            | Mark Miller, Claude Pache                       | 3 |
+|  | [`Promise.prototype.finally`][finally]                           | Jordan Harband                                  | 3 |
+|  | [BigInt][bigint]                                                 | Daniel Ehrenberg                                | 3 |
+|  | [Class Fields][class-fields]                                     | Daniel Ehrenberg, Jeff Morrison                 | 3 |
+|  | [Optional catch binding][optional-catch]                         | Michael Ficarra                                 | 3 |
+|  | [`import.meta`][import-meta]                                     | Domenic Denicola                                | 3 |
+|  | [Private methods and accessors][private-methods]                 | Daniel Ehrenberg, Kevin Gibbons                 | 3 |
+|  | [`function.sent` metaproperty][function-sent]                    | Allen Wirfs-Brock                               | 2 |
+|  | [`String.prototype.{trimStart,trimEnd}`][trims]                  | Sebastian Markbage                              | 2 |
+|  | [Class and Property Decorators][decorators] ([update][unified-class]) | Yehuda Katz and Brian Terlson              | 2 |
+|  | [Numeric separators][numeric_separators]                         | Sam Goto, Rick Waldron                          | 2 |
+|  | [Array.prototype.flat{Map,ten}][flat]                            | Brian Terlson, Michael Ficarra                  | 2 |
+|  | [Throw expressions][throw-expressions]                           | Rob Buckton                                     | 2 |
+|  | [`String#matchAll`][matchall]                                    | Jordan Harband                                  | 2 |
+|  | [`Date.parse` fallback semantics][date-parse]                    | Morgan Phillips                                 | 1 |
+|  | [`export v from "mod";` statements][export-from]                 | Ben Newman and John-David Dalton                | 1 |
+| :rocket: | [Observable][observable]                                 | Jafar Husain and Mark Miller                    | 1 |
+|  | [WeakRefs][weakrefs]                                             | Dean Tribble                                    | 1 |
+|  | [Frozen Realms][frozen-realms]                                   | Mark S. Miller, Chip Morningstar, Caridy Patiño | 1 |
+|  | [`Math` Extensions][more-math]                                   | Rick Waldron                                    | 1 |
+|  | [`of` and `from` on collection constructors][collection-of-from] | Leo Balter                                      | 1 |
+|  | Generator arrow functions (`=>*`)                                | Brendan Eich, Domenic Denicola                  | 1 |
+|  | [`Promise.try`][try]                                             | Jordan Harband                                  | 1 |
+|  | [Optional Chaining][chaining]                                    | Gabriel Isenberg                                | 1 |
+|  | [`Math.signbit`: IEEE-754 sign bit][signbit]                     | JF Bastien                                      | 1 |
+|  | [Error stacks][stacks]                                           | Jordan Harband                                  | 1 |
+|  | [`do` expressions][do]                                           | Dave Herman                                     | 1 |
+|  | [Realms][realms]                                                 | Dave Herman, Mark Miller, Caridy Patiño         | 1 |
+|  | [Temporal][temporal]                                             | Maggie Pint, Brian Terlson                      | 1 |
+|  | [Float16 on TypedArrays, DataView, Math.hfround][float16s]       | Leo Balter                                      | 1 |
+|  | [Atomics.waitNonblocking][nonblocking]                           | Shu-yu Guo, Lars Hansen                         | 1 |
+|  | [`Symbol.prototype.description`][symbol-description]             | Michael Ficarra                                 | 1 |
+|  | change Number.parseInt/parseFloat to not coerce null/undefined/NaN (repo link TBD) | Brendan Eich                  | 1 |
+|  | [Binary AST][binary-ast]                                         | Shu-yu Guo                                      | 1 |
+|  | [Pipeline Operator][pipeline]                                    | Daniel Ehrenberg                                | 1 |
+|  | [Extensible numeric literals][extensible-literals]               | Daniel Ehrenberg                                | 1 |
+|  | [First-Class Protocols][protocols]                               | Michael Ficarra                                 | 1 |
+|  | [JSON superset][json-superset]                                   | Mark Miller, Richard Gibson, Mathias Bynens     | 1 |
+|  | [Nullary coalescing operator][nullary-coalescing]                | Gabriel Isenberg                                | 1 |
+|  | [Partial application][partial-application]                       | Ron Buckton                                     | 1 |
 
-🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.
+:rocket: means the champion thinks it's ready to advance but has not yet presented to the committee.
 
 ### Contributing new proposals
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This list contains only stage 1 proposals and higher that have not yet been with
 |  | [`String.prototype.{trimStart,trimEnd}`][trims]                  | Sebastian Markbage                              |
 |  | [Class and Property Decorators][decorators] ([update][unified-class]) | Yehuda Katz and Brian Terlson              |
 |  | [Numeric separators][numeric_separators]                         | Sam Goto, Rick Waldron                          |
-|  | [Array.prototype.flat{Map,ten}][flat]                            | Brian Terlson, Michael Ficarra                  |
+| :rocket: | [Array.prototype.flat{Map,ten}][flat]                    | Brian Terlson, Michael Ficarra                  |
 |  | [Throw expressions][throw-expressions]                           | Rob Buckton                                     |
 |  | [`String#matchAll`][matchall]                                    | Jordan Harband                                  |
 

--- a/README.md
+++ b/README.md
@@ -11,57 +11,69 @@
 Proposals follow [this process document](https://tc39.github.io/process-document/).
 This list contains only stage 1 proposals and higher that have not yet been withdrawn/rejected, or become finished.
 
-| :rocket: | Proposal                                                 | Champion                                        | Stage |
-|--|------------------------------------------------------------------|-------------------------------------------------|-------|
-|  | [`Function.prototype.toString` revision][function-to-string]     | Michael Ficarra                                 | 3 |
-|  | [`global`][global]                                               | Jordan Harband                                  | 3 |
-|  | [Rest/Spread Properties][object-rest-spread]                     | Sebastian Markbage                              | 3 |
-|  | [Asynchronous Iteration][async-iteration]                        | Domenic Denicola                                | 3 |
-|  | [`import()`][dynamic-import]                                     | Domenic Denicola                                | 3 |
-|  | [RegExp Lookbehind Assertions][lookbehind]                       | Daniel Ehrenberg                                | 3 |
-|  | [RegExp Unicode Property Escapes][unicode-escapes]               | Brian Terlson, Daniel Ehrenberg, Mathias Bynens | 3 |
-|  | [RegExp named capture groups][named-groups]                      | Daniel Ehrenberg, Brian Terlson                 | 3 |
-|  | [`s` (`dotAll`) flag for regular expressions][dot-all]           | Mathias Bynens, Brian Terlson                   | 3 |
-|  | [Legacy RegExp features in JavaScript][regexp-legacy]            | Mark Miller, Claude Pache                       | 3 |
-|  | [`Promise.prototype.finally`][finally]                           | Jordan Harband                                  | 3 |
-|  | [BigInt][bigint]                                                 | Daniel Ehrenberg                                | 3 |
-|  | [Class Fields][class-fields]                                     | Daniel Ehrenberg, Jeff Morrison                 | 3 |
-|  | [Optional catch binding][optional-catch]                         | Michael Ficarra                                 | 3 |
-|  | [`import.meta`][import-meta]                                     | Domenic Denicola                                | 3 |
-|  | [Private methods and accessors][private-methods]                 | Daniel Ehrenberg, Kevin Gibbons                 | 3 |
-|  | [`function.sent` metaproperty][function-sent]                    | Allen Wirfs-Brock                               | 2 |
-|  | [`String.prototype.{trimStart,trimEnd}`][trims]                  | Sebastian Markbage                              | 2 |
-|  | [Class and Property Decorators][decorators] ([update][unified-class]) | Yehuda Katz and Brian Terlson              | 2 |
-|  | [Numeric separators][numeric_separators]                         | Sam Goto, Rick Waldron                          | 2 |
-|  | [Array.prototype.flat{Map,ten}][flat]                            | Brian Terlson, Michael Ficarra                  | 2 |
-|  | [Throw expressions][throw-expressions]                           | Rob Buckton                                     | 2 |
-|  | [`String#matchAll`][matchall]                                    | Jordan Harband                                  | 2 |
-|  | [`Date.parse` fallback semantics][date-parse]                    | Morgan Phillips                                 | 1 |
-|  | [`export v from "mod";` statements][export-from]                 | Ben Newman and John-David Dalton                | 1 |
-| :rocket: | [Observable][observable]                                 | Jafar Husain and Mark Miller                    | 1 |
-|  | [WeakRefs][weakrefs]                                             | Dean Tribble                                    | 1 |
-|  | [Frozen Realms][frozen-realms]                                   | Mark S. Miller, Chip Morningstar, Caridy Patiño | 1 |
-|  | [`Math` Extensions][more-math]                                   | Rick Waldron                                    | 1 |
-|  | [`of` and `from` on collection constructors][collection-of-from] | Leo Balter                                      | 1 |
-|  | Generator arrow functions (`=>*`)                                | Brendan Eich, Domenic Denicola                  | 1 |
-|  | [`Promise.try`][try]                                             | Jordan Harband                                  | 1 |
-|  | [Optional Chaining][chaining]                                    | Gabriel Isenberg                                | 1 |
-|  | [`Math.signbit`: IEEE-754 sign bit][signbit]                     | JF Bastien                                      | 1 |
-|  | [Error stacks][stacks]                                           | Jordan Harband                                  | 1 |
-|  | [`do` expressions][do]                                           | Dave Herman                                     | 1 |
-|  | [Realms][realms]                                                 | Dave Herman, Mark Miller, Caridy Patiño         | 1 |
-|  | [Temporal][temporal]                                             | Maggie Pint, Brian Terlson                      | 1 |
-|  | [Float16 on TypedArrays, DataView, Math.hfround][float16s]       | Leo Balter                                      | 1 |
-|  | [Atomics.waitNonblocking][nonblocking]                           | Shu-yu Guo, Lars Hansen                         | 1 |
-|  | [`Symbol.prototype.description`][symbol-description]             | Michael Ficarra                                 | 1 |
-|  | change Number.parseInt/parseFloat to not coerce null/undefined/NaN (repo link TBD) | Brendan Eich                  | 1 |
-|  | [Binary AST][binary-ast]                                         | Shu-yu Guo                                      | 1 |
-|  | [Pipeline Operator][pipeline]                                    | Daniel Ehrenberg                                | 1 |
-|  | [Extensible numeric literals][extensible-literals]               | Daniel Ehrenberg                                | 1 |
-|  | [First-Class Protocols][protocols]                               | Michael Ficarra                                 | 1 |
-|  | [JSON superset][json-superset]                                   | Mark Miller, Richard Gibson, Mathias Bynens     | 1 |
-|  | [Nullary coalescing operator][nullary-coalescing]                | Gabriel Isenberg                                | 1 |
-|  | [Partial application][partial-application]                       | Ron Buckton                                     | 1 |
+### Stage 3
+
+| :rocket: | Proposal                                                 | Champion                                        |
+|--|------------------------------------------------------------------|-------------------------------------------------|
+|  | [`Function.prototype.toString` revision][function-to-string]     | Michael Ficarra                                 |
+|  | [`global`][global]                                               | Jordan Harband                                  |
+|  | [Rest/Spread Properties][object-rest-spread]                     | Sebastian Markbage                              |
+|  | [Asynchronous Iteration][async-iteration]                        | Domenic Denicola                                |
+|  | [`import()`][dynamic-import]                                     | Domenic Denicola                                |
+|  | [RegExp Lookbehind Assertions][lookbehind]                       | Daniel Ehrenberg                                |
+|  | [RegExp Unicode Property Escapes][unicode-escapes]               | Brian Terlson, Daniel Ehrenberg, Mathias Bynens |
+|  | [RegExp named capture groups][named-groups]                      | Daniel Ehrenberg, Brian Terlson                 |
+|  | [`s` (`dotAll`) flag for regular expressions][dot-all]           | Mathias Bynens, Brian Terlson                   |
+|  | [Legacy RegExp features in JavaScript][regexp-legacy]            | Mark Miller, Claude Pache                       |
+|  | [`Promise.prototype.finally`][finally]                           | Jordan Harband                                  |
+|  | [BigInt][bigint]                                                 | Daniel Ehrenberg                                |
+|  | [Class Fields][class-fields]                                     | Daniel Ehrenberg, Jeff Morrison                 |
+|  | [Optional catch binding][optional-catch]                         | Michael Ficarra                                 |
+|  | [`import.meta`][import-meta]                                     | Domenic Denicola                                |
+|  | [Private methods and accessors][private-methods]                 | Daniel Ehrenberg, Kevin Gibbons                 |
+
+### Stage 2
+
+| :rocket: | Proposal                                                 | Champion                                        |
+|--|------------------------------------------------------------------|-------------------------------------------------|
+|  | [`function.sent` metaproperty][function-sent]                    | Allen Wirfs-Brock                               |
+|  | [`String.prototype.{trimStart,trimEnd}`][trims]                  | Sebastian Markbage                              |
+|  | [Class and Property Decorators][decorators] ([update][unified-class]) | Yehuda Katz and Brian Terlson              |
+|  | [Numeric separators][numeric_separators]                         | Sam Goto, Rick Waldron                          |
+|  | [Array.prototype.flat{Map,ten}][flat]                            | Brian Terlson, Michael Ficarra                  |
+|  | [Throw expressions][throw-expressions]                           | Rob Buckton                                     |
+|  | [`String#matchAll`][matchall]                                    | Jordan Harband                                  |
+
+### Stage 1
+
+| :rocket: | Proposal                                                 | Champion                                        |
+|--|------------------------------------------------------------------|-------------------------------------------------|
+|  | [`Date.parse` fallback semantics][date-parse]                    | Morgan Phillips                                 |
+|  | [`export v from "mod";` statements][export-from]                 | Ben Newman and John-David Dalton                |
+| :rocket: | [Observable][observable]                                 | Jafar Husain and Mark Miller                    |
+|  | [WeakRefs][weakrefs]                                             | Dean Tribble                                    |
+|  | [Frozen Realms][frozen-realms]                                   | Mark S. Miller, Chip Morningstar, Caridy Patiño |
+|  | [`Math` Extensions][more-math]                                   | Rick Waldron                                    |
+|  | [`of` and `from` on collection constructors][collection-of-from] | Leo Balter                                      |
+|  | Generator arrow functions (`=>*`)                                | Brendan Eich, Domenic Denicola                  |
+|  | [`Promise.try`][try]                                             | Jordan Harband                                  |
+|  | [Optional Chaining][chaining]                                    | Gabriel Isenberg                                |
+|  | [`Math.signbit`: IEEE-754 sign bit][signbit]                     | JF Bastien                                      |
+|  | [Error stacks][stacks]                                           | Jordan Harband                                  |
+|  | [`do` expressions][do]                                           | Dave Herman                                     |
+|  | [Realms][realms]                                                 | Dave Herman, Mark Miller, Caridy Patiño         |
+|  | [Temporal][temporal]                                             | Maggie Pint, Brian Terlson                      |
+|  | [Float16 on TypedArrays, DataView, Math.hfround][float16s]       | Leo Balter                                      |
+|  | [Atomics.waitNonblocking][nonblocking]                           | Shu-yu Guo, Lars Hansen                         |
+|  | [`Symbol.prototype.description`][symbol-description]             | Michael Ficarra                                 |
+|  | change Number.parseInt/parseFloat to not coerce null/undefined/NaN (repo link TBD) | Brendan Eich                  |
+|  | [Binary AST][binary-ast]                                         | Shu-yu Guo                                      |
+|  | [Pipeline Operator][pipeline]                                    | Daniel Ehrenberg                                |
+|  | [Extensible numeric literals][extensible-literals]               | Daniel Ehrenberg                                |
+|  | [First-Class Protocols][protocols]                               | Michael Ficarra                                 |
+|  | [JSON superset][json-superset]                                   | Mark Miller, Richard Gibson, Mathias Bynens     |
+|  | [Nullary coalescing operator][nullary-coalescing]                | Gabriel Isenberg                                |
+|  | [Partial application][partial-application]                       | Ron Buckton                                     |
 
 :rocket: means the champion thinks it's ready to advance but has not yet presented to the committee.
 

--- a/ecma402/README.md
+++ b/ecma402/README.md
@@ -10,18 +10,30 @@
 Proposals follow [this process document](https://tc39.github.io/process-document/).
 This list contains only stage 1 proposals and higher that have not yet been withdrawn/rejected, or become finished.
 
-| 🚀 | Proposal                                                         | Champion                                        | Stage |
-|---|------------------------------------------------------------------|-------------------------------------------------| ------|
-|   | [Intl.Segmenter: Unicode segmentation in JavaScript][]           | Daniel Ehrenberg                                | 3 |
-|   | [Intl.RelativeTimeFormat][]                                      | Zibi Braniecki, Daniel Ehrenberg                | 2 |
-|   | [Intl.ListFormat][]                                              | Zibi Braniecki                                  | 2 |
-|   | [Exposing Abstract Operations & Locale Info][]                   | Zibi Braniecki                                  | 2 |
-|   | [Intl.Locale][]                                                  | Zibi Braniecki, Daniel Ehrenberg                | 1 |
-|   | [Intl.DurationFormat][]                                          | Zibi Braniecki                                  | 1 |
-|   | [Intl.UnitFormat][]                                              | Zibi Braniecki                                  | 1 |
-|   | [DateTimeFormat dateStyle & timeStyle][]                         | Zibi Braniecki                                  | 1 |
+### Stage 3
 
-🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.
+| :rocket: | Proposal                                                 | Champion                                        |
+|--|------------------------------------------------------------------|-------------------------------------------------|
+|  | [Intl.Segmenter: Unicode segmentation in JavaScript][]           | Daniel Ehrenberg                                |
+
+### Stage 2
+
+| :rocket: | Proposal                                                 | Champion                                        |
+|--|------------------------------------------------------------------|-------------------------------------------------|
+|  | [Intl.RelativeTimeFormat][]                                      | Zibi Braniecki, Daniel Ehrenberg                |
+|  | [Intl.ListFormat][]                                              | Zibi Braniecki                                  |
+|  | [Exposing Abstract Operations & Locale Info][]                   | Zibi Braniecki                                  |
+
+### Stage 1
+
+| :rocket: | Proposal                                                 | Champion                                        |
+|--|------------------------------------------------------------------|-------------------------------------------------|
+|  | [Intl.Locale][]                                                  | Zibi Braniecki, Daniel Ehrenberg                |
+|  | [Intl.DurationFormat][]                                          | Zibi Braniecki                                  |
+|  | [Intl.UnitFormat][]                                              | Zibi Braniecki                                  |
+|  | [DateTimeFormat dateStyle & timeStyle][]                         | Zibi Braniecki                                  |
+
+:rocket: means the champion thinks it's ready to advance but has not yet presented to the committee.
 
 ### Contributing new proposals
 


### PR DESCRIPTION
This makes it a bit easier to move proposals between stages, and allows one to link to all of the proposals of a particular stage. At the same time, just removes a bunch of duplicate data.

Also, started using `:rocket:` and added a :rocket: to my flatMap proposal.