### PR TITLE
Move `Object.shallowEqual` to inactive proposals list

### DIFF
--- a/inactive-proposals.md
+++ b/inactive-proposals.md
@@ -16,6 +16,7 @@ Inactive proposals are proposals that at one point were presented to the committ
 | [Dynamic Module Reform][dynamic-module-reform]                       | Caridy Patiño                        | Withdrawn: we decided to preserve the current semantics
 | [SIMD.JS - SIMD APIs][simd]                                          | Peter Jensen, Yehuda Katz            | [Stage 1][simd-notes]: Start with SIMD in WASM; implementations not pursuing SIMD.js for now.
 | [Updates to Tail Calls to include an explicit syntactic opt-in][ptc] | Brian Terlson & Eric Faust           | Inactive |
+| [Object.shallowEqual][shallow-equal]                                 | Sebastian Markbage                   | Withdrawn |
 
 
 See also the [stage 0 proposals](stage-0-proposals.md), [active proposals](README.md), and [finished proposals](finished-proposals.md) documents.
@@ -35,3 +36,4 @@ See also the [stage 0 proposals](stage-0-proposals.md), [active proposals](READM
 [simd]: https://github.com/tc39/ecmascript_simd/
 [simd-notes]: https://github.com/rwaldron/tc39-notes/blob/master/es8/2017-03/mar-21.md#conclusionresolution-10
 [ptc]: https://github.com/tc39/proposal-ptc-syntax
+[shallow-equal]: https://github.com/sebmarkbage/ecmascript-shallow-equal

--- a/stage-0-proposals.md
+++ b/stage-0-proposals.md
@@ -26,7 +26,6 @@ Stage 0 proposals are either
 |   | [Structured Clone][clone]                                                  | Dmitry Lomov                         | 0     |
 |   | [WHATWG URL][url]                                                          | James M Snell                        | 0     |
 |   | [Zones][zones] ([spec][zones-spec])                                        | Domenic Denicola & Miško Hevery      | 0     |
-|   | [Object.shallowEqual][shallow-equal]                                       | Sebastian Markbage                   | 0     |
 |   | [Object Shorthand Improvements][object-shorthand-improvements]             | Ron Buckton                          | 0     |
 |   | [`Builtins.typeOf()` and `Builtins.is()`][is-types]                        | James M Snell                        | 0     |
 |   | [`ArrayBuffer.transfer`][buffer-transfer]                                  | Domenic Denicola                     | 0     |
@@ -56,7 +55,6 @@ See also the [finished proposals](finished-proposals.md), [active proposals](REA
 [url]: https://github.com/jasnell/proposal-url
 [zones]: https://github.com/domenic/zones
 [zones-spec]: https://domenic.github.io/zones/
-[shallow-equal]: https://github.com/sebmarkbage/ecmascript-shallow-equal
 [object-shorthand-improvements]: https://github.com/rbuckton/proposal-shorthand-improvements
 [is-types]: https://github.com/jasnell/proposal-istypes
 [buffer-transfer]: https://gist.github.com/lukewagner/2735af7eea411e18cf20


### PR DESCRIPTION
GitHub repo of `Object.shallowEqual` [reports](https://github.com/sebmarkbage/ecmascript-shallow-equal/commit/36ea2c58d40453b1a690fc6d771c6fb9857d7d92) that it's withdrawn, so move it to inactive proposals list.