### PR TITLE
removing 'Class Static Fields' from stage2 table

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ This list contains only stage 1 proposals and higher that have not yet been with
 
 | :rocket: | Proposal                                                 | Champion                                        |
 |--|------------------------------------------------------------------|-------------------------------------------------|
-|  | [Class Static Fields (Public & Private)][class-fields]           | Daniel Ehrenberg, Jeff Morrison                 |
 |  | [`function.sent` metaproperty][function-sent]                    | Allen Wirfs-Brock                               |
 |  | [`String.prototype.{trimStart,trimEnd}`][trims]                  | Sebastian Markbage                              |
 |  | [Decorators][decorators]                                         | Yehuda Katz, Brian Terlson and Daniel Ehrenberg |


### PR DESCRIPTION
The link in "Class Static Fields (Public & Private)", which was under stage 2; says it's now in stage3.
Under stage 3 table this link is already added with title "Class Public Instance Fields & Private Instance Fields & Methods".

Thus removed that from stage 2 list.

