### PR TITLE
Add `deprecated` proposal

### DIFF
--- a/stage-0-proposals.md
+++ b/stage-0-proposals.md
@@ -29,6 +29,7 @@ Stage 0 proposals are either
 |          | [`Builtins.typeOf()` and `Builtins.is()`][is-types]                | James M Snell                         | James M Snell                         | [Sep 2017][builtins-notes]  |
 |          | [`ArrayBuffer.transfer`][buffer-transfer]                          | Domenic Denicola                      | Domenic Denicola                      | [Sep 2017][transfer-notes]  |
 |          | [Decimal][decimal]                                                 | Andrew Paprocki<br />Daniel Ehrenberg | Andrew Paprocki<br />Daniel Ehrenberg | [Nov 2017][decimal-notes]   |
+|          | [`deprecated`][deprecated]                                         | James M Snell                         | James M Snell                         |                             |
 
 🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.
 
@@ -56,6 +57,7 @@ See also the [finished proposals](finished-proposals.md), [active proposals](REA
 [buffer-transfer]: https://gist.github.com/lukewagner/2735af7eea411e18cf20
 [decimal]: https://docs.google.com/presentation/d/1jPsw7EGsS6BW59_BDRu9o0o3UwSXQeUhi38QG55ZoPI/edit?pli=1#slide=id.p
 [module-keys]: https://github.com/mikesamuel/tc39-module-keys
+[deprecated]: https://github.com/jasnell/proposal-deprecated
 
 [bind-notes]: https://github.com/tc39/tc39-notes/blob/b8da60318b564f136cbe8385f17f42abc0666cdd/es6/2015-03/mar-25.md#6vi-function-bind-and-private-fields-redux-kevin-smith
 [nested-notes]: https://github.com/tc39/tc39-notes/blob/b8da60318b564f136cbe8385f17f42abc0666cdd/es7/2016-07/jul-27.md#10iiic-nested-import-declaration


### PR DESCRIPTION
Introduces a new proposal to better handle deprecations.

Please refer to the Never-Ending-Buffer-Constructor-Deprecation-Saga (e.g. https://github.com/nodejs/node/issues/19079) for reference on what is triggering this.