### PR TITLE
Add issue template pointing to the ecma262 contributing doc

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!--
+This repository is NOT the right place to suggest new ECMAScript features.
+See the "Contributing to ECMAScript" document in the ecma262 repository for
+information on how to do that:
+https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md
+
+Issues in this repository should regard the list of proposals or the process for
+tracking proposals.
+-->


### PR DESCRIPTION
This should hopefully help clarify that this repository isn't the right place to
suggest language features.

See this help page for GitHub docs on issue templates:
https://help.github.com/articles/creating-an-issue-template-for-your-repository/

I used the same convention as CONTRIBUTING.md and CODE_OF_CONDUCT.md.