### PR TITLE
Add JSON Comments to “Stage 0 Proposals”

### DIFF
--- a/stage-0-proposals.md
+++ b/stage-0-proposals.md
@@ -27,6 +27,7 @@ Stage 0 proposals are either
 |          | [`deprecated`][deprecated]                                         | James M Snell                         | James M Snell                         |                             |
 |          | [`as` destructuring patterns][as-patterns]                         | Kat Marchán                           | Kat Marchán                           |                             |
 |          | [`Symbol.thenable`][symbol-thenable]                               | Gus Caplan                            | Jordan Harband<br />Myles Borins      |
+|          | [JSON Comments][json-comments]                                     | ExE Boss                              |                                       |                             |
 
 🚀 means the champion thinks it's ready to advance but has not yet presented to the committee.
 
@@ -61,3 +62,4 @@ See also the [finished proposals](finished-proposals.md), [active proposals](REA
 [builtins-notes]: https://github.com/tc39/tc39-notes/blob/61dc2f45829a0663af0b4b1d6690717dc70d30d9/es8/2017-09/sep-28.md#14ia-builtinstypeof-and-builtinsis
 [decimal-notes]: https://github.com/rwaldron/tc39-notes/blob/b8da60318b564f136cbe8385f17f42abc0666cdd/es8/2017-11/nov-29.md#9ivb-decimal-for-stage-0
 [symbol-thenable]: https://github.com/devsnek/proposal-symbol-thenable
+[json-comments]: https://github.com/ExE-Boss/tc39-proposal-json-comments


### PR DESCRIPTION
## Quoting [EB-Tech/tc39-proposal-json-comments README.md](https://github.com/EB-Tech/tc39-proposal-json-comments/blob/master/README.md):

<blockquote>

JSON Comments
=============

Allow comments in JSON data passed to `JSON.parse(…)`.

## Motivation

Comments help annotate configuration or localisation files, which are stored in the JSON file format.

The fact that they were removed from the JSON specification simply because Douglas Crockford didn't like them is a terrible reason, and an [overwhelming majority of web developers agree that removing them was dumb](https://redd.it/4v6chu).

Many JSON parsers already support comments, with the JSON parser built into ECMAScript being part of a minority of JSON parsers that don't support comments.

## Example

```json
/*
 * Multi-line comment
 */
{
	// Single-line comment
	"foo": "bar"
}
```