### PR TITLE
Added HostEnsureCanCompileStrings and evalable

### DIFF
--- a/stage-0-proposals.md
+++ b/stage-0-proposals.md
@@ -11,8 +11,10 @@ Stage 0 proposals are either
 | Annex B — HTML Attribute Event Handlers                            | Allen Wirfs-Brock                     | Allen Wirfs-Brock                     |                             |
 | [Array.isTemplateObject][isTemplateObject]                         | Mike Samuel                           | Mike Samuel                               |                             |
 | [Defensible Classes][defensible-classes]                           | Mark Miller<br />Doug Crockford       | Mark Miller<br />Doug Crockford       |                             |
+| [evalable][]                                                       | Mike Samuel                           | Mike Samuel                            |                             |
 | [Function bind syntax][bind-syntax]                                | Kevin Smith                           | Brian Terlson<br />Matthew Podwysocki | [March 2015][bind-notes]    |
 | [Function expression decorators][func-expr-decorators]             | Igor Minar                            | Igor Minar                            |                             |
+| [HostEnsureCanCompileStrings passthrough][heccspt]                 | Mike Samuel                           | Mike Samuel                               |                             |
 | [Method parameter decorators][method-param-decorators]             | Igor Minar                            | Igor Minar                            |                             |
 | [Nested `import` declarations][nested-imports]                     | Ben Newman                            | Ben Newman                            | [July 2016][nested-notes]   |
 | [Normative ICU Reference][icu]                                     | Domenic Denicola                      | Domenic Denicola                      | [May 2017][icu-notes]       |
@@ -61,3 +63,5 @@ See also the [finished proposals](finished-proposals.md), [active proposals](REA
 [decimal-notes]: https://github.com/rwaldron/tc39-notes/blob/b8da60318b564f136cbe8385f17f42abc0666cdd/es8/2017-11/nov-29.md#9ivb-decimal-for-stage-0
 [symbol-thenable]: https://github.com/devsnek/proposal-symbol-thenable
 [isTemplateObject]: https://github.com/mikesamuel/proposal-array-is-template-object
+[heccspt]: https://github.com/mikesamuel/proposal-hostensurecancompilestrings-passthru
+[evalable]: https://github.com/mikesamuel/evalable


### PR DESCRIPTION
These would provide github.com/wicg/trusted-types what it needs to provide source-to-sink security for code strings.