### PR TITLE
Update features tests links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Stage 2 indicates that the committee expects these features to be developed and 
 | [Static class fields and private static methods][static-class-features]        | Daniel Ehrenberg<br />Kevin Gibbons<br />Jeff Morrison<br />Kevin Smith | Shu-Yu Guo<br />Daniel Ehrenberg                                        | :question:                                     | <sub>[January&nbsp;2019][class-fields-notes]</sub>      |
 | [Hashbang Grammar][hashbang-grammar]                                           | Bradley Farias                                                          | Bradley Farias                                                          | [:white_check_mark:][tests-hashbang-grammar]   | <sub>[November&nbsp;2018][hashbang-notes]</sub>         |
 | [Numeric separators][numeric_separators]                                       | Sam Goto<br />Rick Waldron                                              | Sam Goto<br />Rick Waldron                                              | [:white_check_mark:][tests-numeric_separators] | <sub>[June&nbsp;2019][numeric_separators-notes]</sub>   |
-| [Top-level `await`][await]                                                     | Myles Borins                                                            | Myles Borins                                                            | :question:                                     | <sub>[June&nbsp;2019][await-notes]</sub>                |
+| [Top-level `await`][await]                                                     | Myles Borins                                                            | Myles Borins                                                            | [:white_check_mark:][tests-await]              | <sub>[June&nbsp;2019][await-notes]</sub>                |
 | [WeakRefs][weakrefs]                                                           | Dean Tribble<br />Sathya Gunasekaran                          | Dean Tribble<br />Mark Miller<br />Till Schneidereit<br />Sathya Gunasekaran      | [:white_check_mark:][tests-weakrefs]           | <sub>[June&nbsp;2019][weakrefs-notes]</sub>             |
-| [Nullish coalescing Operator][nullish-coalescing]                              | Gabriel Isenberg                                                        | Gabriel Isenberg<br />Justin Ridgewell<br />Daniel Rosenwasser          | :question:                                     | <sub>[July 2019][nullish-coalescing-notes]</sub>        |
+| [Nullish coalescing Operator][nullish-coalescing]                              | Gabriel Isenberg                                                        | Gabriel Isenberg<br />Justin Ridgewell<br />Daniel Rosenwasser          | [:white_check_mark:][tests-nullish-coalescing] | <sub>[July 2019][nullish-coalescing-notes]</sub>        |
 | [RegExp Match array offsets][regex-offsets]                                    | Ron Buckton                                                             | Ron Buckton                                                             | :question:                                     | <sub>[July 2019][regex-offsets-notes]</sub>             |
-| [Optional Chaining][chaining]                                                  | Gabriel Isenberg<br />Claude Pache<br />Dustin Savery         | Gabriel Isenberg<br />Dustin Savery<br />Justin Ridgewell<br />Daniel Rosenwasser | :question:                                     | <sub>[July 2019][chaining-notes]</sub>                  |
+| [Optional Chaining][chaining]                                                  | Gabriel Isenberg<br />Claude Pache<br />Dustin Savery         | Gabriel Isenberg<br />Dustin Savery<br />Justin Ridgewell<br />Daniel Rosenwasser | [:white_check_mark:][tests-chaining]           | <sub>[July 2019][chaining-notes]</sub>                  |
 | [`for-in` mechanics][for-in-mechanics]                                         | Kevin Gibbons                                                           | Kevin Gibbons                                                           | :question:                                     | <sub>October&nbsp;2019</sub>                            |
-| [`String.prototype.replaceAll`][replace-all]                                   | Peter Marshall<br />Jakob Gruber<br />Mathias Bynens          | Mathias Bynens                                                                    | :question:                                     | <sub>October&nbsp;2019</sub>                            |
-| [`Promise.any`][promise-any]                                                   | Mathias Bynens<br />Kevin Gibbons<br />Sergey Rubanov         | Mathias Bynens                                                                    | :question:                                     | <sub>October 2019</sub>                                 |
+| [`String.prototype.replaceAll`][replace-all]                                   | Peter Marshall<br />Jakob Gruber<br />Mathias Bynens                    | Mathias Bynens                                                                    | :question:                                     | <sub>October&nbsp;2019</sub>                            |
+| [`Promise.any`][promise-any]                                                   | Mathias Bynens<br />Kevin Gibbons<br />Sergey Rubanov                   | Mathias Bynens                                                                    | :question:                                     | <sub>October 2019</sub>                                 |
 
 ### Stage 2
 
@@ -75,19 +75,23 @@ Note that as part of the onboarding process your repository name may be normaliz
 
 [regexp-legacy]: https://github.com/tc39/proposal-regexp-legacy-features
 [regexp-legacy-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2017-05/may-25.md#15ia-regexp-legacy-features-for-stage-3
+[tests-regexp-legacy]: https://github.com/tc39/test262/issues/2371
 [class-fields]: https://github.com/tc39/proposal-class-fields
 [class-fields-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-01/jan-30.md#private-fields-and-methods-refresher
+[tests-class-fields]: https://github.com/tc39/test262/issues/1161
 [function-sent]: https://github.com/tc39/proposal-function.sent
 [function-sent-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-07/july-23.md#making-functionsent-inactive
 [decorators]: http://github.com/tc39/proposal-decorators
 [decorators-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-01/jan-30.md#decorators-for-stage-3
 [import-meta]: https://github.com/tc39/proposal-import-meta
 [import-meta-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2017-09/sept-27.md#12iiic-importmeta-for-stage-3
+[tests-import-meta]: https://github.com/tc39/test262/pull/1888
 [numeric_separators]: https://github.com/tc39/proposal-numeric-separator
 [numeric_separators-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-03/mar-28.md#decorator-based-extended-numeric-literals-status-update-and-numeric-separators-for-stage-3
 [tests-numeric_separators]: https://test262.report/features/numeric-separator-literal
 [private-methods]: https://github.com/tc39/proposal-private-methods
 [private-methods-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-01/jan-30.md#private-fields-and-methods-refresher
+[tests-private-methods]: https://github.com/tc39/test262/issues/1343
 [weakrefs]: https://github.com/tc39/proposal-weakrefs
 [weakrefs-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-06/june-6.md#weakrefs
 [tests-weakrefs]: https://github.com/tc39/test262/pull/2192
@@ -103,16 +107,11 @@ Note that as part of the onboarding process your repository name may be normaliz
 [replace-all-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-03/mar-26.md#stringprototypereplaceall-for-stage-2
 [static-class-features]: http://github.com/tc39/proposal-static-class-features/
 [static-class-features-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2018-05/may-23.md#static-class-features-for-stage-3
-[tests-global]: https://github.com/tc39/test262/issues/765
-[tests-import-meta]: https://github.com/tc39/test262/pull/1888
-[tests-regexp-legacy]: https://github.com/tc39/test262/issues/2371
-[tests-private-methods]: https://github.com/tc39/test262/issues/1343
-[tests-numeric_separators]: https://github.com/tc39/test262/issues/1051
-[tests-class-fields]: https://github.com/tc39/test262/issues/1161
 [censorship]: https://github.com/domenic/proposal-function-implementation-hiding
 [censorship-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2018-05/may-24.md#functionprototypetostring-censorship-for-stage-2-continued-discussion
 [await]: https://github.com/tc39/proposal-top-level-await
 [await-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-06/june-6.md#top-level-await-for-stage-3
+[tests-await]: https://github.com/tc39/test262/pull/2274
 [set-methods]: https://github.com/tc39/set-methods
 [set-methods-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-01/jan-29.md#update-on-set-methods
 [hashbang-grammar]: https://github.com/tc39/proposal-hashbang
@@ -142,8 +141,10 @@ Note that as part of the onboarding process your repository name may be normaliz
 [isTemplateObject-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-06/june-5.md#arrayistemplateobject-for-stage-1-or-2
 [chaining]: https://github.com/tc39/proposal-optional-chaining
 [chaining-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-07/july-25.md#optional-chaining-for-stage-3
+[tests-chaining]: https://github.com/tc39/test262/pull/2212
 [nullish-coalescing]: https://github.com/tc39/proposal-nullish-coalescing
 [nullish-coalescing-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-07/july-23.md#nullish-coalescing
+[tests-nullish-coalescing]: https://github.com/tc39/test262/pull/2402
 [promise-any]: https://github.com/tc39/proposal-promise-any
 [promise-any-notes]: https://github.com/tc39/tc39-notes/blob/master/meetings/2019-07/july-24.md#promiseany
 [resource-management]: https://github.com/tc39/proposal-using-statement


### PR DESCRIPTION
- Added nullish coalescing, optional chaining and top-level await tests links
- Removed tests link for globalThis (moved to finished proposals list earlier)
- Removed duplicate tests link for numeric separators