### PR TITLE
Proper Spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ Stage 2 indicates that the committee expects these features to be developed and 
 | [Record & Tuple][record-tuple]                                                 | Robin Ricard<br />Richard Button                      | Robin Ricard<br />Richard Button                                                  | <sub>July&nbsp;2020</sub>                                                |
 | [JSON.parse source text access][json-parse-source]                             | Richard Gibson                                        | Richard Gibson                                                                    | <sub>July&nbsp;2020</sub>                                                |
 
-:white_check_mark: means a pull request for tests was merged.
+:white_check_mark: means a pull request for tests was merged.
 
-:question: means there is no pull request for tests yet.
+:question: means there is no pull request for tests yet.
 
-:construction: means a pull request for tests was created, but not merged yet.
+:construction: means a pull request for tests was created, but not merged yet.
 
 ### Contributing new proposals
 


### PR DESCRIPTION
I updated the space character from a normal spacebar to something called a UTF* space character (the other possible way was using `&nbsp;` twice maybe.) This helps create a small space between the emoji and the text following it which otherwise looked like overlapping a bit in some browsers.

Reference for space character: https://stackoverflow.com/questions/44810511/how-to-add-empty-spaces-into-md-markdown-readme-on-github 