### PR TITLE
Withdraw Object Iteration proposal

### DIFF
--- a/inactive-proposals.md
+++ b/inactive-proposals.md
@@ -31,6 +31,7 @@ Inactive proposals are proposals that at one point were presented to the committ
 | [`from ... import`][fromimport] | Bradley Farias | Never presented; preliminary feedback about syntax cost not being worth the weight |
 | [TypedArray stride parameter][typedarray-stride-parameter]           | Shu-yu Guo                                                 | Withdrawn: concern about performance implications, and the proposal is not expressive enough
 | [Unused Function Parameters][unused-params]                          | Gus Caplan                                                 | Rejected: the need to solve the problem does not outweigh the hazards
+| [Improving iteration on Objects][object-iteration]                                           | Jonathan Keslin                                       | Jonathan Keslin                                        | Withdrawn: concern about need for such an API                |
 
 See also the [active proposals](README.md), [stage 1 proposals](stage-1-proposals.md), [stage 0 proposals](stage-0-proposals.md), and [finished proposals](finished-proposals.md) documents.
 
@@ -67,3 +68,4 @@ See also the [active proposals](README.md), [stage 1 proposals](stage-1-proposal
 [fromimport]: https://github.com/bmeck/proposal-from-import
 [typedarray-stride-parameter]: https://github.com/tc39/proposal-typedarray-stride
 [unused-params]: https://github.com/devsnek/proposal-unused-function-parameters
+[object-iteration]: https://github.com/tc39/proposal-object-iteration

--- a/stage-1-proposals.md
+++ b/stage-1-proposals.md
@@ -49,7 +49,6 @@ Proposals follow [this process document](https://tc39.es/process-document/).
 | [Emitter][emitter]                                                                           | Shu-yu Guo<br />Pedram Emrouznejad                    | Shu-yu Guo<br />Pedram Emrouznejad                     | <sub>[June&nbsp;2019][emitter-notes]</sub>                        |
 | [Dynamic Code Brand Checks][dynamic-code-brand-checks]                                       | Mike Samuel                                           | Mike Samuel                                            | <sub>[December&nbsp;2019][dynamic-code-brand-checks-notes]</sub>  |
 | [Reverse iteration][reverse-iteration]                                                       | Leo Balter<br />Jordan Harband                        | Leo Balter<br />Jordan Harband                         | <sub>[July&nbsp;2019][reverse-iteration-notes]</sub>                   |
-| [Improving iteration on Objects][object-iteration]                                           | Jonathan Keslin                                       | Jonathan Keslin                                        | <sub>[February&nbsp;2020][object-iteration-notes]</sub>                |
 | [Declarations in Conditionals][declarations-in-conditionals]                                 | Devin Rousso                                          | Devin Rousso                                           | <sub>[October&nbsp;2019][declarations-in-conditionals-notes]</sub>     |
 | [UUID][uuid]                                                                                | Benjamin Coe<br />Robert Kieffer <br />Christoph Tavan | Benjamin Coe                                           | <sub>[October&nbsp;2019][uuid-notes]</sub>                             |
 | [Readonly Collections][readonly-collections]                                                 | Mark Miller<br />Peter Hoddie                         | Mark Miller<br />Peter Hoddie                          | <sub>[October&nbsp;2019][readonly-collections-notes]</sub>             |
@@ -165,8 +164,6 @@ See also the [active proposals](README.md), [stage 0 proposals](stage-0-proposal
 [dynamic-code-brand-checks-notes]: https://github.com/tc39/notes/blob/master/meetings/2019-12/december-5.md#dynamic-code-brand-checks-for-stage-2
 [reverse-iteration]: https://github.com/tc39/proposal-reverseIterator
 [reverse-iteration-notes]: https://github.com/tc39/notes/blob/master/meetings/2019-07/july-23.md#symbolreverse
-[object-iteration]: https://github.com/tc39/proposal-object-iteration
-[object-iteration-notes]: https://github.com/tc39/notes/blob/master/meetings/2020-02/february-5.md#object-iteration-for-stage-2
 [declarations-in-conditionals]: https://github.com/tc39/proposal-Declarations-in-Conditionals
 [declarations-in-conditionals-notes]: https://github.com/tc39/notes/blob/master/meetings/2019-10/october-2.md#declarations-in-conditionals
 [uuid]: https://github.com/tc39/proposal-uuid


### PR DESCRIPTION
Per discussion during the February 2020 meeting, there does not seem to be interest in adding an API for object iteration. As such, I am withdrawing this proposal from consideration.