### PR TITLE
Add Array Grouping to stage 1 proposals

### DIFF
--- a/stage-1-proposals.md
+++ b/stage-1-proposals.md
@@ -83,6 +83,7 @@ Proposals follow [this process document](https://tc39.es/process-document/).
 | [Change Array by copy][change-array-by-copy]                                                 | Robin Ricard                                           | Robin Ricard                                          | <sub>[April&nbsp;2021][change-array-by-copy-notes]</sub>          |
 | [Limited ArrayBuffer][limited-array-buffer]                                                  | Jack Works                                             | Jack Works                                            | <sub>[April&nbsp;2021][limited-array-buffer-notes]</sub>          |
 | [ArrayBuffer to/from Base64][arraybuffer-base64]                                             | Kevin Gibbons                                          | Kevin Gibbons                                         | <sub>July&nbsp;2021</sub>                                         |
+| [Array Grouping][array-grouping]                                                             | Justin Ridgewell                                       | Justin Ridgewell                                      | <sub>July&nbsp;2021</sub>                                         |
 
 See also the [active proposals](README.md), [stage 0 proposals](stage-0-proposals.md), [finished proposals](finished-proposals.md), and [inactive proposals](inactive-proposals.md) documents.
 
@@ -239,3 +240,4 @@ See also the [active proposals](README.md), [stage 0 proposals](stage-0-proposal
 [limited-array-buffer]: https://github.com/tc39/proposal-limited-arraybuffer
 [limited-array-buffer-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2021-04/apr-21.md#read-only-arraybuffer-and-fixed-view-of-arraybuffer-for-stage-1
 [arraybuffer-base64]: https://github.com/bakkot/proposal-arraybuffer-base64
+[array-grouping]: https://github.com/tc39/proposal-array-grouping


### PR DESCRIPTION
[Array Grouping](https://github.com/tc39/proposal-array-grouping) seems to reach stage 1 at July 2021 meeting.

/cc @jridgewell 