### PR TITLE
doc: make contributing instructions discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # [ECMAScript](https://github.com/tc39/ecma262) proposals
 
-## Contributing new proposals
-
-Please see [Contributing to ECMAScript](https://github.com/tc39/ecma262/blob/HEAD/CONTRIBUTING.md) for the most up-to-date information on contributing proposals to this standard.
-
 * [Stage 1 Proposals](stage-1-proposals.md)
 * [Stage 0 Proposals](stage-0-proposals.md)
 * [Finished Proposals](finished-proposals.md)
 * [Inactive Proposals](inactive-proposals.md)
 
 [ECMAScript Internationalization API Specification](ecma402/README.md) proposals
+
+## Contributing new proposals
+
+Please see [Contributing to ECMAScript](https://github.com/tc39/ecma262/blob/HEAD/CONTRIBUTING.md) for the most up-to-date information on contributing proposals to this standard.
 
 ## Active proposals
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # [ECMAScript](https://github.com/tc39/ecma262) proposals
 
+## Contributing new proposals
+
+Please see [Contributing to ECMAScript](https://github.com/tc39/ecma262/blob/HEAD/CONTRIBUTING.md) for the most up-to-date information on contributing proposals to this standard.
+
 * [Stage 1 Proposals](stage-1-proposals.md)
 * [Stage 0 Proposals](stage-0-proposals.md)
 * [Finished Proposals](finished-proposals.md)
@@ -59,10 +63,6 @@ Stage 2 indicates that the committee expects these features to be developed and 
 :question: means there is no pull request for tests yet.
 
 :construction: means a pull request for tests was created, but not merged yet.
-
-### Contributing new proposals
-
-Please see [Contributing to ECMAScript](https://github.com/tc39/ecma262/blob/HEAD/CONTRIBUTING.md) for the most up-to-date information on contributing proposals to this standard.
 
 ### Onboarding existing proposals
 


### PR DESCRIPTION
Currently the instructions to making a new proposal are near the bottom of the document and hard to find.
Moving it to just below the title will make it easier to find for folks new to the process...

...or whom forgot said process 😅