### PR TITLE
New Proposal: TypeArray encoding

### DIFF
--- a/stage-0-proposals.md
+++ b/stage-0-proposals.md
@@ -23,7 +23,7 @@ Stage 0 proposals are either
 | [`Symbol.thenable`][symbol-thenable]                               | Gus Caplan                            | Jordan Harband<br />Myles Borins      | [May 2018][symbol-thenable-notes] |
 | [Async Context][async-context]                                     | Chengzhong Wu                         | Chengzhong Wu                         | [July 2020][async-context-notes]  |
 | [String trim characters][string-trim-characters]                   | Wenlu Wang                            | Wenlu Wang                            |                                   |
-
+| [TypedArray encoding][typedarray-encoding]                         | James M Snell                         | James M Snell                         |                                   |
 
 See also the [active proposals](README.md), [stage 1 proposals](stage-1-proposals.md), [finished proposals](finished-proposals.md), and [inactive proposals](inactive-proposals.md) documents.
 
@@ -51,3 +51,4 @@ See also the [active proposals](README.md), [stage 1 proposals](stage-1-proposal
 [async-context]: https://github.com/legendecas/proposal-async-context
 [async-context-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2020-07/july-23.md#async-context-updates--for-stage-1
 [string-trim-characters]: https://github.com/Kingwl/proposal-string-trim-characters
+[typedarray-encoding]: https://github.com/jasnell/tc39-proposal-hex-base64


### PR DESCRIPTION
Proposes a new API for `TypedArray` to support built-in `hex`, `base64`, `base64url`, and `base32` encoding.

Example:
```
const u8 = Uint8Array.fromEncodedString('abcdef', 'hex')

console.log(u8.toEncodedString('base64url'))
```

Currently, each runtime has to handle these differently. Node.js has it's non-standard `Buffer` API, Deno has its own APIs, browser developers have to choose from a variety of userland options. These encodings are common enough, however, that they warrant being built into the language.

My goal will be to present this at an upcoming TC-39, but also looking for a champion.