### PR TITLE
New Proposal: await spread operator

### DIFF
--- a/stage-0-proposals.md
+++ b/stage-0-proposals.md
@@ -23,6 +23,7 @@ Stage 0 proposals are either
 | [`Symbol.thenable`][symbol-thenable]                               | Gus Caplan                            | Jordan Harband<br />Myles Borins      | [May 2018][symbol-thenable-notes] |
 | [Async Context][async-context]                                     | Chengzhong Wu                         | Chengzhong Wu                         | [July 2020][async-context-notes]  |
 | [String trim characters][string-trim-characters]                   | Wenlu Wang                            | Wenlu Wang                            |                                   |
+| [await spread opreator][await-spread-operator]                     | Tuğrul Topuz                          |                                       |                                   |
 
 
 See also the [active proposals](README.md), [stage 1 proposals](stage-1-proposals.md), [finished proposals](finished-proposals.md), and [inactive proposals](inactive-proposals.md) documents.
@@ -51,3 +52,4 @@ See also the [active proposals](README.md), [stage 1 proposals](stage-1-proposal
 [async-context]: https://github.com/legendecas/proposal-async-context
 [async-context-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2020-07/july-23.md#async-context-updates--for-stage-1
 [string-trim-characters]: https://github.com/Kingwl/proposal-string-trim-characters
+[await-spread-operator]: https://github.com/tugrul/tc39-proposal-await-spread-operator


### PR DESCRIPTION

Similar fashion of spread operator but await each promises before expanding.

```js
// const [foo, bar] = await Promise.all([taskFoo(), taskBar()]);
const [foo, bar] = [await...[taskFoo(), taskBar()]];

const obj = {await...{name: getAsyncName()}, await...{surname: getAsyncSurname()}};

otherFunc(await...[getAsyncName(), getAsyncSurname()])
```

