### PR TITLE
Add proposal for object-nullish-coalescing

### DIFF
--- a/stage-0-proposals.md
+++ b/stage-0-proposals.md
@@ -24,6 +24,7 @@ Stage 0 proposals are either
 | [Async Context][async-context]                                     | Chengzhong Wu                         | Chengzhong Wu                         | [July 2020][async-context-notes]  |
 | [String trim characters][string-trim-characters]                   | Wenlu Wang                            | Wenlu Wang                            |                                   |
 | [Catch Guard][catch-guard]                                         | Willian Martins                       | Willian Martins                       |                                   |
+| [Object nullish coalescing][object-nullish-coalescing]             | Bert Verhelst                         | Bert Verhelst                         |                                   |
 
 See also the [active proposals](README.md), [stage 1 proposals](stage-1-proposals.md), [finished proposals](finished-proposals.md), and [inactive proposals](inactive-proposals.md) documents.
 
@@ -52,3 +53,4 @@ See also the [active proposals](README.md), [stage 1 proposals](stage-1-proposal
 [async-context-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2020-07/july-23.md#async-context-updates--for-stage-1
 [string-trim-characters]: https://github.com/Kingwl/proposal-string-trim-characters
 [catch-guard]: https://github.com/wmsbill/proposal-catch-guards
+[object-nullish-coalescing]: https://github.com/bertyhell/object-assignment-null-properties


### PR DESCRIPTION
Proposal for Object property nullish coalescing operator

This proposal shows a new syntax for assigning properties to an object literal but only if the object is not falsy/null or undefined.

Short example:
```javascript
const myPersonObj = {
	firstName: person.name,
	work?: person.occupation,   // Only set work if person.occupation is truthy, by using the "?:" operator
	street??: person.address    // Only set street is person.address is not null and not undefined, by using the "??:" operator
};
```