### PR TITLE
Update Time Zone Canonicalization proposal info

### DIFF
--- a/stage-1-proposals.md
+++ b/stage-1-proposals.md
@@ -96,7 +96,7 @@ Proposals follow [this process document](https://tc39.es/process-document/).
 | [Prototype pollution mitigation][proto-pollution]                                            | Santiago Díaz<br />Jun Kokatsu                         | Shu-Yu Guo                                            | <sub>[January&nbsp;2023][proto-pollution-notes]</sub>             |
 | [Await Dictionary][await-dictionary]                                                         | Alexander J. Vincent                                   | Ashley Claymore<br />Jordan Harband<br />Chris de Almeida | <sub>March 2023</sub>                                         |
 | [`Promise.withResolvers`][promise-defer]                                                     | Peter Klecha                                           | Peter Klecha<br />Chris de Almeida                    | <sub>March 2023</sub>                                             |
-| [Time Zone Canonicalization][time-zone-canon]                                                | Justin Grant                                           | Justin Grant                                          | <sub>March 2023</sub>                                             |
+| [Time Zone Canonicalization][time-zone-canon]                                                | Justin Grant                                           | Justin Grant<br />Richard Gibson                      | <sub>March 2023</sub>                                             |
 | [Class Method Parameter Decorators][class-param-decorators]                                  | Ron Buckton                                            | Ron Buckton                                           | <sub>March 2023</sub>                                             |
 
 See also the [active proposals](README.md), [stage 0 proposals](stage-0-proposals.md), [finished proposals](finished-proposals.md), and [inactive proposals](inactive-proposals.md) documents.
@@ -278,5 +278,5 @@ See also the [active proposals](README.md), [stage 0 proposals](stage-0-proposal
 [proto-pollution-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2023-01/jan-30.md#prototype-pollution-mitigation--symbolproto
 [await-dictionary]: https://github.com/acutmore/proposal-await-dictionary
 [promise-defer]: https://github.com/peetklecha/proposal-promise-with-resolvers
-[time-zone-canon]: https://github.com/justingrant/proposal-canonical-tz#readme
+[time-zone-canon]: https://github.com/tc39/proposal-canonical-tz#readme
 [class-param-decorators]: https://github.com/rbuckton/proposal-class-method-parameter-decorators


### PR DESCRIPTION
Switches repo URL to tc39 org.
Adds Richard Gibson as co-champion.