### PR TITLE
Uint8Array to/from base64 to stage 2, per 2023.05.15 TC39

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Stage 2 indicates that the committee expects these features to be developed and 
 | [Async Context][async-context]                                                 | Chengzhong Wu                                         | Chengzhong Wu<br />Justin Ridgewell                                               | <sub>[March&nbsp;2023][async-context-notes]</sub>                     |
 | [Time Zone Canonicalization][time-zone-canon]                                  | Justin Grant                                          | Justin Grant<br />Richard Gibson                                                  | <sub>[May&nbsp;2023][time-zone-canon-notes]</sub>                     |
 | [Deferring Module Evaluation][lazy-import]                                     | Yulia Startsev<br />Guy Bedford                       | Yulia Startsev<br />Guy Bedford<br />Nicolò Ribaudo                               | <sub>[July&nbsp;2023][lazy-import-notes]</sub>                        |
-| [`RegExp.escape`][escape]                                         | Domenic Denicola<br />Benjamin Gruenbaum<br />Jordan Harband | Jordan Harband                                                                          | <sub>September&nbsp;2023</sub>                                        |
+| [`RegExp.escape`][escape]                                               | Domenic Denicola<br />Benjamin Gruenbaum<br />Jordan Harband | Jordan Harband                                                                    | <sub>September&nbsp;2023</sub>                                        |
+| [Uint8Array to/from Base64][uint8array-base64]                                 | Kevin Gibbons                                         | Kevin Gibbons                                                                     | <sub>[July&nbsp;2023][uint8array-base64-notes]<br />September&nbsp;2023</sub> |
 
 The test262 feature flag links to a code search of tests using that feature flag, which may constitute complete or partial coverage.
 The :question: means there is no feature flag for tests yet.
@@ -180,3 +181,5 @@ Note that as part of the onboarding process your repository name may be normaliz
 [lazy-import-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2023-07/july-11.md#deferred-import-evaluation
 [escape]: https://github.com/tc39/proposal-regex-escaping
 [escape-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2021-01/jan-28.md#revisiting-regexp-escape
+[uint8array-base64]: https://github.com/tc39/proposal-arraybuffer-base64
+[uint8array-base64-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2023-07/july-12.md#base64

--- a/stage-1-proposals.md
+++ b/stage-1-proposals.md
@@ -73,7 +73,6 @@ Proposals follow [this process document](https://tc39.es/process-document/).
 | [`async do` expressions][async-do]                                                           | Kevin Gibbons                                          | Kevin Gibbons                                         | <sub>[January&nbsp;2021][async-do-notes]</sub>                    |
 | [Class Brand Checks][class-brand-check]                                                      | HE Shi-Jun                                             | HE Shi-Jun                                            | <sub>[January&nbsp;2021][class-brand-check-notes]</sub>           |
 | [Limited ArrayBuffer][limited-array-buffer]                                                  | Jack Works                                             | Jack Works                                            | <sub>[April&nbsp;2021][limited-array-buffer-notes]</sub>          |
-| [ArrayBuffer to/from Base64][arraybuffer-base64]                                             | Kevin Gibbons                                          | Kevin Gibbons                                         | <sub>[July&nbsp;2021][arraybuffer-base64-notes]</sub>             |
 | [BigInt Math][bigint-math]                                                                   | J.S. Choi                                              | J.S. Choi                                             | <sub>[August&nbsp;2021][bigint-math-notes]</sub>                  |
 | [Get Intrinsic][get-intrinsic]                                                               | Jordan Harband                                         | Jordan Harband                                        | <sub>[August&nbsp;2021][get-intrinsic-notes]</sub>                |
 | [Structs: Fixed Layout Objects and Some Synchronization Primitives][structs]                 | Shu-yu Guo                                             | Shu-yu Guo                                            | <sub>[August&nbsp;2021][structs-notes]</sub>                      |
@@ -237,8 +236,6 @@ See also the [active proposals](README.md), [stage 0 proposals](stage-0-proposal
 [class-brand-check-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2021-01/jan-27.md#class-brand-checks
 [limited-array-buffer]: https://github.com/tc39/proposal-limited-arraybuffer
 [limited-array-buffer-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2021-04/apr-21.md#read-only-arraybuffer-and-fixed-view-of-arraybuffer-for-stage-1
-[arraybuffer-base64]: https://github.com/tc39/proposal-arraybuffer-base64
-[arraybuffer-base64-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2021-07/july-14.md#arraybuffer-tofrom-base64
 [bigint-math]: https://github.com/tc39/proposal-bigint-math
 [bigint-math-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2021-10/oct-26.md#bigint-math-update
 [get-intrinsic]: https://github.com/tc39/proposal-get-intrinsic


### PR DESCRIPTION
This was apparently missed for the past three meetings.