### PR TITLE
🎨 update contribution information, fix structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@
 
 [ECMAScript Internationalization API Specification](ecma402/README.md) proposals
 
-See also: [How We Work](https://github.com/tc39/how-we-work) for guidance on how proposals advance.
-
-## Contributing new proposals
-
-Please see [Contributing to ECMAScript](https://github.com/tc39/ecma262/blob/HEAD/CONTRIBUTING.md) for the most up-to-date information on contributing proposals to this standard.
+[Contributing to proposals](#contributing-to-proposals)
 
 ## Active proposals
 
@@ -79,13 +75,17 @@ Stage 2 indicates that the committee expects these features to be developed and 
 The test262 feature flag links to a code search of tests using that feature flag, which may constitute complete or partial coverage.
 The :question: means there is no feature flag for tests yet.
 
-### Onboarding existing proposals
+## Contributing to proposals
 
-Proposals that are Stage 1 and above must be transferred to [the TC39 GitHub organization](https://github.com/tc39) for discoverability and archival purposes. To onboard a proposal that lives outside the TC39 organization:
+See [Contributing to ECMAScript](https://github.com/tc39/ecma262/blob/HEAD/CONTRIBUTING.md) and [How We Work](https://github.com/tc39/how-we-work/blob/main/README.md#proposals) for the most up-to-date information on contributing to proposals to TC39 standards and how proposals advance.
+
+### Onboarding proposals
+
+Proposals that are Stage 1 and above must be transferred to [the TC39 GitHub organization](https://github.com/tc39) for discoverability and archival purposes. To onboard a proposal:
 
 1. Transfer your repository to the [@tc39-transfer](http://github.com/tc39-transfer) organization
-  - if you are a TC39 delegate, but not a member of that organization, please contact [@LJHarb](https://github.com/ljharb)
-2. The Github Administrator, or One of the chairs, will transfer your repository to the TC39 organization the next chance they get.
+   * if you are a TC39 delegate, but not a member of that organization, please contact [@LJHarb](https://github.com/ljharb)
+2. The Github Administrator, or one of the chairs, will transfer your repository to the TC39 organization the next chance they get.
 
 Note that as part of the onboarding process your repository name may be normalized. Don't worry, repo redirects will continue to work **as long as** you never create a fork, or a new repository, with the same name - although Github Pages redirects will be broken (please update your links!).
 


### PR DESCRIPTION
- moves the contribution information to the bottom of the readme
- adds a link to that information at the top of the readme
- adds a link to how-we-work
- fixes structure (onboarding topic was nested within active proposals topic and not colocated with contributing topic)
- minor clarifications in wording, grammar fixes