### PR TITLE
Update Measure/Amount metadata

### DIFF
--- a/ecma402/README.md
+++ b/ecma402/README.md
@@ -40,7 +40,6 @@ This list contains only stage 1 proposals and higher that have not yet been with
 | [`Intl.MessageFormat`][intl.messageformat]                   | Eemeli Aro           | Eemeli Aro             | March&nbsp;2022                                                  |
 | [`Intl.MessageResource`][intl.messageresource]               | Eemeli Aro           | Eemeli Aro             | November&nbsp;2022                                               |
 | [Intl.ZonedDateTimeFormat][intl.zoneddatetimeformat]         | Frank Yung-Fong Tang | Frank Yung-Fong Tang   | May&nbsp;2023                                                    |
-| [Representing Measures][measure]                             | Ben Allen            | Ben Allen              | October&nbsp;2024                                                |
 
 ### Contributing new proposals
 
@@ -69,5 +68,4 @@ Note that as part of the onboarding process your repository name may be normaliz
 [intl.messageresource]: https://github.com/tc39/proposal-intl-message-resource
 [intl era monthCode]: https://github.com/tc39/proposal-intl-era-monthcode
 [intl.zoneddatetimeformat]: https://github.com/FrankYFTang/intl-zoneddatetimeformat
-[measure]: https://github.com/ben-allen/proposal-measure
 [mo-money]: https://github.com/eemeli/proposal-intl-currency-display-choices

--- a/stage-1-proposals.md
+++ b/stage-1-proposals.md
@@ -107,6 +107,7 @@ Proposals follow [this process document](https://tc39.es/process-document/).
 | [More Random Functions][more-random-functions]                                               | Tab Atkins                                             | Tab Atkins                                            | <sub>[May&nbsp;2025][more-random-functions-notes]</sub>                                          |
 | [Inspector][inspector]                                                                       | Jacob Smith                                            | Jacob Smith                                           | <sub>May&nbsp;2025</sub>                                          |
 | [Module Global][module-global]                                                               | Zbyszek Tenerowicz<br />Kris Kowal<br />Richard Gibson<br />Mark S. Miller | Zbyszek Tenerowicz<br />Kris Kowal<br />Richard Gibson<br />Mark S. Miller | <sub>[July&nbsp;2025][module-global-notes]</sub> |
+| [Representing Measures/Amounts][measure]                                                     | Ben Allen                                              | Ben Allen                                             | <sub>September&nbsp;2025</sub>                                    |
 | [Bulk-add array elements][bulk-add-array]                                                    | Daniel Rosenwasser                                     | Daniel Rosenwasser                                    | <sub>September&nbsp;2025</sub>                                    |
 
 See also the [active proposals](README.md), [stage 0 proposals](stage-0-proposals.md), [finished proposals](finished-proposals.md), and [inactive proposals](inactive-proposals.md) documents.
@@ -311,4 +312,5 @@ See also the [active proposals](README.md), [stage 0 proposals](stage-0-proposal
 [inspector]: https://github.com/tc39/proposal-inspector
 [module-global]: https://github.com/endojs/proposal-new-global
 [module-global-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2025-07/july-30.md#module-import-hook-and-new-global-for-stage-1
+[measure]: https://github.com/tc39/proposal-amount
 [bulk-add-array]: https://github.com/DanielRosenwasser/proposal-array-push-all/


### PR DESCRIPTION
* Reclassify Measure/Amount as "stage 1" rather than "ecma402"
* Update name to include "Amount" (for discoverability)
* Update link to https://github.com/tc39/proposal-amount
* Update Last Presented to September 2025 (cf. [notes PR](https://github.com/tc39/notes/pull/384/files#diff-4807bdfa40372936c04c812b15b979d1ad74c9ed73dadedf1b2f0c4fc1b51c94R516))