### PR TITLE
Import sync stage 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ Stage 2 indicates that the committee expects these features to be developed and 
 | [`Math.clamp`][clamp]                                                          | Oliver Medhurst                                       | Oliver Medhurst                                                                   |                                            | <sub>[May&nbsp;2025][clamp-notes]</sub>                               |
 | [Native Promise Predicate][native-promise-predicate]                           | Mathieu Hofman                                        | Mathieu Hofman                                                                    | Jordan Harband<br />James Snell<br />Justin Ridgewell | <sub>[September&nbsp;2025][native-promise-predicate-notes]</sub> |
 | [`Error.captureStackTrace`][capturestacktrace]                                 | Matthew Gaudet                                        | Matthew Gaudet<br />Dan Minor                                                     | Jordan Harband<br />Michael Ficarra        | <sub>[February&nbsp;2025][capturestacktrace-notes]</sub>              |
-| [Import Text][import-text]                                                     | Eemeli Aro                                            | Eemeli Aro                                                                        | Jordan Harband<br />Nicolò Ribaudo         | <sub>[November&nbsp;2025][import-text-notes]</sub>                                         |
+| [Import Text][import-text]                                                     | Eemeli Aro                                            | Eemeli Aro                                                                        | Jordan Harband<br />Nicolò Ribaudo         | <sub>[November&nbsp;2025][import-text-notes]</sub>                    |
 | [`Object.keysLength`][keyslength]                                              | Ruben Bridgewater<br />Jordan Harband                 | Ruben Bridgewater<br />Jordan Harband                                             | Eemeli Aro<br />James Snell                | <sub>November&nbsp;2025</sub>                                         |
+| [Sync Imports][import-sync]                                                    | Guy Bedford                                           | Guy Bedford                                                                       | Nicolò Ribaudo<br />James Snell            | <sub>January&nbsp;2026</sub>                                          |
 
 The test262 feature flag links to a code search of tests using that feature flag, which may constitute complete or partial coverage.
 The :question: means there is no feature flag for tests yet.
@@ -192,6 +193,7 @@ Note that as part of the onboarding process your repository name may be normaliz
 [clamp-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2025-05/may-29.md#mathclamp-for-stage-2
 [import-bytes]: https://github.com/styfle/proposal-import-buffer
 [import-bytes-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2025-09/september-23.md#import-bytes-for-stage-27
+[import-sync]: https://github.com/tc39/proposal-import-sync
 [native-promise-predicate]: https://github.com/mhofman/proposal-native-promise-predicate
 [native-promise-predicate-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2025-09/september-22.md#native-promise-predicate-for-stage-1-or-2
 [capturestacktrace]: https://github.com/tc39/proposal-error-capturestacktrace

--- a/stage-1-proposals.md
+++ b/stage-1-proposals.md
@@ -95,7 +95,6 @@ Proposals follow [this process document](https://tc39.es/process-document/).
 | [Unordered Async Iterator Helpers][unordered-async]                                          | Michael Ficarra                                        | Michael Ficarra                                       | <sub>[July&nbsp;2024][unordered-async-notes]</sub>                |
 | [`Array.zip` and `Array.zipKeyed`][array.zip]                                                | Jordan Harband                                         | Jordan Harband                                        | <sub>[October&nbsp;2024][array.zip-notes]</sub>                   |
 | [Stabilize][stabilize]                                                                       | Mark Miller<br />Chip Morningstar<br />Richard Gibson<br />Mathieu Hofman | Mark Miller<br />Chip Morningstar<br />Richard Gibson<br />Mathieu Hofman | <sub>[December&nbsp;2024][stabilize-notes]</sub> |
-| [Sync Imports][import-sync]                                                                  | Guy Bedford                                            | Guy Bedford                                           | <sub>[December&nbsp;2024][import-sync-notes]</sub>                |
 | [Curtailing the power of "Thenables"][thenables]                                             | Matthew Gaudet                                         | Matthew Gaudet                                        | <sub>[February&nbsp;2025][thenables-notes]</sub>                  |
 | [`Composites`][composite]                                                                    | Ashley Claymore                                        | Ashley Claymore                                       | <sub>[April&nbsp;2025][composite-notes]</sub>                     |
 | [Enums][enum]                                                                                | Ron Buckton                                            | Ron Buckton                                           | <sub>[April&nbsp;2025][enum-notes]</sub>                          |
@@ -292,8 +291,6 @@ See also the [active proposals](README.md), [stage 0 proposals](stage-0-proposal
 [array.zip-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2024-10/october-09.md#arrayzip-for-stage-1-or-2-or-27
 [stabilize]: https://github.com/tc39/proposal-stabilize
 [stabilize-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2024-12/december-03.md#stabilize-to-stage-1
-[import-sync]: https://github.com/tc39/proposal-import-sync
-[import-sync-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2024-12/december-04.md#import-sync-discussion-request-for-stage-1
 [thenables]: https://github.com/tc39/proposal-thenable-curtailment
 [thenables-notes]: https://github.com/tc39/notes/blob/HEAD/meetings/2025-02/february-18.md#curtailing-the-power-of-thenables-for-stage-1
 [composite]: https://github.com/tc39/proposal-composites


### PR DESCRIPTION
Adds `import.sync` to Stage 2, with @nicolo-ribaudo and @jasnell as Stage 2.7 reviewers.